### PR TITLE
Allow "no test" as well as "no tests"

### DIFF
--- a/tom/bot.py
+++ b/tom/bot.py
@@ -232,7 +232,7 @@ class Bot:
         # flag if docs build is requested
         docs = pr.short_repo_name.startswith("documentation")
 
-        no_tests = "no tests" in comment
+        no_tests = "no test" in comment
         if no_tests:
             description += " [NO TESTS]"
 


### PR DESCRIPTION
Easier and less to remember. Do I have to say tests or just test?

Ticket: none
Changelog: none