### PR TITLE
Added feature to ping a given mantainer per repo for dependabot PRs

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,8 +66,51 @@
     {
       "username": "mender-test-bot",
       "secrets": "mender-secrets.json",
-      "bot_features": ["report_open_prs"],
-      "orgs": [ "mendersoftware" ]
+      "bot_features": [
+        "report_open_prs",
+        "ping_reviewers_dependabot"
+      ],
+      "orgs": [ "mendersoftware" ],
+
+      "repos_dependabot" : {
+        "mendersoftware/gui": "mzedel",
+        "mendersoftware/integration": "lluiscampos",
+        "mendersoftware/meta-mender": "lluiscampos",
+        "mendersoftware/mender": "lluiscampos",
+        "mendersoftware/mender-artifact": "lluiscampos",
+        "mendersoftware/mender-cli": "lluiscampos",
+        "mendersoftware/mender-connect": "lluiscampos",
+        "mendersoftware/mender-binary-delta": "lluiscampos",
+        "mendersoftware/mender-dist-packages": "lluiscampos",
+        "mendersoftware/mender-demo-artifact": "lluiscampos",
+        "mendersoftware/mender-convert": "lluiscampos",
+        "mendersoftware/mender-test-containers": "lluiscampos",
+        "mendersoftware/mender-stress-test-client": "lluiscampos",
+        "mendersoftware/integration-test-runner": "lluiscampos",
+        "mendersoftware/mender-gateway": "lluiscampos",
+        "mendersoftware/auditlogs": "kjaskiewiczz",
+        "mendersoftware/create-artifact-worker": "kjaskiewiczz",
+        "mendersoftware/deployments": "kjaskiewiczz",
+        "mendersoftware/deployments-enterprise": "kjaskiewiczz",
+        "mendersoftware/deviceauth": "kjaskiewiczz",
+        "mendersoftware/deviceauth-enterprise": "kjaskiewiczz",
+        "mendersoftware/deviceconfig": "kjaskiewiczz",
+        "mendersoftware/deviceconnect": "kjaskiewiczz",
+        "mendersoftware/devicemonitor": "kjaskiewiczz",
+        "mendersoftware/generate-delta-worker": "kjaskiewiczz",
+        "mendersoftware/inventory": "kjaskiewiczz",
+        "mendersoftware/inventory-enterprise": "kjaskiewiczz",
+        "mendersoftware/iot-manager": "kjaskiewiczz",
+        "mendersoftware/mender-configure-module": "kjaskiewiczz",
+        "mendersoftware/monitor-client": "kjaskiewiczz",
+        "mendersoftware/mtls-ambassador": "kjaskiewiczz",
+        "mendersoftware/reporting": "kjaskiewiczz",
+        "mendersoftware/tenantadm": "kjaskiewiczz",
+        "mendersoftware/useradm": "kjaskiewiczz",
+        "mendersoftware/useradm-enterprise": "kjaskiewiczz",
+        "mendersoftware/workflows": "kjaskiewiczz",
+        "mendersoftware/workflows-enterprise": "kjaskiewiczz"
+      }
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -71,8 +71,7 @@
         "ping_reviewers_dependabot"
       ],
       "orgs": [ "mendersoftware" ],
-
-      "repos_dependabot" : {
+      "repo_dependabot_maintainers" : {
         "mendersoftware/gui": "mzedel",
         "mendersoftware/integration": "lluiscampos",
         "mendersoftware/meta-mender": "lluiscampos",

--- a/tom/bot.py
+++ b/tom/bot.py
@@ -84,8 +84,8 @@ class Bot:
         if self.interactive:
             print("I'd like to POST something")
             msg = "" if msg is None else msg
-            msg += "Path: {}".format(path)
-            msg += "Data: {}".format(data)
+            msg += "\nPath: {}".format(path)
+            msg += "\nData: {}".format(data)
             if not confirmation(msg):
                 return False
         r = self.github.post(path, data)
@@ -95,7 +95,7 @@ class Bot:
 
     def comment(self, pr, message):
         path = pr.comments_url
-        pr_string = "PR: {} ({}#{})".format(pr.title, pr.repo, pr.number)
+        pr_string = "PR: {} ({})".format(pr.title, pr.url)
         data = {"body": str(message)}
         commented = self.post(path, data, pr_string)
         if commented:

--- a/tom/bot.py
+++ b/tom/bot.py
@@ -31,7 +31,7 @@ class Bot:
         self.username = config["username"]
         self.orgs = config.get("orgs", [])
         self.repo_maintainers = config.get("repos", {})
-        self.repo_dependabot_maintainers = config.get("repos_dependabot", {})
+        self.repo_dependabot_maintainers = config.get("repo_dependabot_maintainers", {})
         self.default_maintainers = config.get("reviewers", [])
         self.trusted = config.get("trusted", [])
 
@@ -312,11 +312,11 @@ class Bot:
     def assign_dependabot_maintainer(self, pr):
         if pr.author != "dependabot[bot]":
             return
-        if pr.repo not in self.repos_dependabot:
+        if pr.repo not in self.repo_dependabot_maintainers:
             log.warning(f"A dependabot PR in {pr.repo} with no assigned maintainer!")
             return
 
-        pr.reviewer = self.repos_dependabot[pr.repo]
+        pr.reviewer = self.repo_dependabot_maintainers[pr.repo]
 
     def handle_pr(self, pr):
         log.info("Looking at: {} ({})".format(pr["title"], pr["html_url"]))

--- a/tom/bot.py
+++ b/tom/bot.py
@@ -31,6 +31,7 @@ class Bot:
         self.username = config["username"]
         self.orgs = config.get("orgs", [])
         self.repo_maintainers = config.get("repos", {})
+        self.repo_dependabot_maintainers = config.get("repos_dependabot", {})
         self.default_maintainers = config.get("reviewers", [])
         self.trusted = config.get("trusted", [])
 
@@ -103,6 +104,10 @@ class Bot:
             print("")
 
     def ping_reviewer(self, pr):
+        if pr.reviewer is None:
+            log.info("I don't know who to ping, no human set as reviewer")
+            return
+
         if pr.age < datetime.timedelta(days=1):
             log.info("This PR is less than a day old, I won't ping yet")
         elif self.username in pr.comments.users:
@@ -304,12 +309,27 @@ class Bot:
             pr.reviewers = self.default_maintainers
         pr.reviewer = random.choice(pr.reviewers)
 
+    def assign_dependabot_maintainer(self, pr):
+        if pr.author != "dependabot[bot]":
+            return
+        if pr.repo not in self.repos_dependabot:
+            log.warning(f"A dependabot PR in {pr.repo} with no assigned maintainer!")
+            return
+
+        pr.reviewer = self.repos_dependabot[pr.repo]
+
     def handle_pr(self, pr):
         log.info("Looking at: {} ({})".format(pr["title"], pr["html_url"]))
 
         pr = PR(pr, self.github)
         if "ping_reviewers" in self.bot_features:
             self.find_reviewers(pr)
+        if "ping_reviewers_dependabot" in self.bot_features:
+            self.assign_dependabot_maintainer(pr)
+        if (
+            "ping_reviewers" in self.bot_features
+            or "ping_reviewers_dependabot" in self.bot_features
+        ):
             self.ping_reviewer(pr)
         if (
             "check_commit_emails" in self.bot_features

--- a/tom/bot.py
+++ b/tom/bot.py
@@ -305,7 +305,6 @@ class Bot:
         pr.reviewer = random.choice(pr.reviewers)
 
     def handle_pr(self, pr):
-        url = pr["url"].replace("https://api.github.com/repos/", "")
         log.info("Looking at: {} ({})".format(pr["title"], pr["html_url"]))
 
         pr = PR(pr, self.github)

--- a/tom/github.py
+++ b/tom/github.py
@@ -23,6 +23,7 @@ class GitHub:
         }
         self.get_cache = {}
         self.known_repos = known_repos
+        self.reviewer = None
 
     def path(self, path):
         if path.startswith("/"):

--- a/tom/github.py
+++ b/tom/github.py
@@ -23,7 +23,6 @@ class GitHub:
         }
         self.get_cache = {}
         self.known_repos = known_repos
-        self.reviewer = None
 
     def path(self, path):
         if path.startswith("/"):
@@ -452,6 +451,9 @@ class PR:
         self.commits_url = data["commits_url"]
         self.reviews_url = self.api_url + "/reviews"
         self.requested_reviewers = data["requested_reviewers"]
+
+        # The person which will be pinged for review (based on config)
+        self.reviewer = None
 
         self.created = datetime.datetime.strptime(
             data["created_at"], "%Y-%m-%dT%H:%M:%SZ"

--- a/tom/packages.py
+++ b/tom/packages.py
@@ -112,7 +112,7 @@ class PackageMapper:
                 "Updating packages mapping for %s %s " % (value_type, value)
             )
             result = {"agent": {}, "hub": {}}
-            for (product, codename) in [
+            for product, codename in [
                 ("community", "community"),
                 ("enterprise", "nova"),
             ]:


### PR DESCRIPTION
    Used in the Mender team where each subteam (frontend, backend and
    client) has a single person responsible for dependabot reviews and
    updates.
    
    The feature is enabled only for `mender-test-bot` bot and has hard-coded
    maintainers per repository. We will modify it as we rotate the role.