### PR TITLE
GitHub Actions: Specified Ubuntu 20 explicitly

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
AFAICT when ubuntu-latest starts to become ubuntu 22, Python 3.5 and 3.6 will fail.