### PR TITLE
Add misc to list of repos which have _REV params sent to jenkins

### DIFF
--- a/tom/jenkins.py
+++ b/tom/jenkins.py
@@ -99,6 +99,7 @@ class Jenkins:
             "enterprise",
             "masterfiles",
             "nova",
+            "misc",
         ]
         if "fast-build-and-deploy-docs" not in path:
             repos_accepted.extend(


### PR DESCRIPTION
We added MISC_REV to pr-pipeline and vagrant-pr jobs to accomodate checking misc repo changes to vagrant-quickstart in a PR/jenkins run.