### PR TITLE
Adjusted README and tom.cf to reflect use of class default:tom_enabled and flagfile TOM_DISABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,22 @@ Note that this is referred to in the release process doc: https://github.com/Nor
 
 See the [example policy](/tom.cf) for an automated way to update and run Tom.
 
-To disable policy when testing, you can delete this flag file:
+To enable tom, add the class `default:tom_enabled` via CMDB or augments.
+
+To disable running for testing/debugging, create this flag file:
 
 ```
 $ cd /home/tom
-$ rm TOM_ENABLE
+$ touch TOM_DISABLED
 ```
 
-The `TOM_ENABLE` file is checked by the policy, not the python code.
+The `TOM_DISABLED` file is checked by the policy, not the python code.
+
 To re-enable:
 
 ```
 $ cd /home/tom
-$ touch TOM_ENABLE
+$ rm -f TOM_DISABLED
 ```
 
 ## Config

--- a/tom.cf
+++ b/tom.cf
@@ -107,11 +107,12 @@ bundle agent tom_main
        if => filesexist( @(config_files) );
 
     vars:
-        "config_files" slist => {"/home/tom/config.json",
-                                 "/home/tom/TOM_ENABLE"};
+        "config_files" slist => {"/home/tom/config.json"};
 
     classes:
         "has_tom_config" expression => filesexist(@(config_files));
+        "tom_enabled" expression => and("default:tom_enabled",
+                                        not(fileexists("/home/tom/TOM_DISABLED")));
 
     methods:
         has_tom_config::
@@ -121,10 +122,12 @@ bundle agent tom_main
                 usebundle => "tom_update";
             "Install"
                 usebundle => "tom_install";
+
+        tom_enabled::
             "Run"
                 usebundle => "tom_run";
     reports:
-        inform_mode.!has_tom_config::
+        inform_mode.!has_tom_config.!tom_enabled::
             "Skipping execution, config.json or TOM_ENABLE missing in /home/tom";
 }
 


### PR DESCRIPTION
In order to make provisioning tom easier with policy the class `default:tom_enabled` is used.
To support local debugging the new flag file `/home/tom/TOM_DISABLED` is added to the policy.

Ticket: ENT-11788
